### PR TITLE
Revert change to FloatState enum and restore individual tiltback states

### DIFF
--- a/float/ui.qml
+++ b/float/ui.qml
@@ -107,11 +107,11 @@ Item {
                 }else if(state == 1){
                     stateString = "RUNNING"
                 }else if(state == 2){
-                    stateString = "RUNNING_TILTBACK"
+                    stateString = "RUNNING_TILTBACK_DUTY"
                 }else if(state == 3){
-                    stateString = "RUNNING_WHEELSLIP"
+                    stateString = "RUNNING_TILTBACK_HIGH_VOLTAGE"
                 }else if(state == 4){
-                    stateString = "RUNNING_UPSIDEDOWN"
+                    stateString = "RUNNING_TILTBACK_LOW_VOLTAGE"
                 }else if(state == 6){
                     stateString = "STOP_ANGLE_PITCH"
                 }else if(state == 7){
@@ -128,8 +128,14 @@ Item {
                         stateString = "STARTUP"
                     }
                 }else if(state == 12){
-                    stateString = "STOP_REVERSE"
+                    stateString = "RUNNING_TILTBACK_TEMP"
                 }else if(state == 13){
+                    stateString = "RUNNING_WHEELSLIP"
+                }else if(state == 14){
+                    stateString = "RUNNING_UPSIDEDOWN"
+                }else if(state == 15){
+                    stateString = "STOP_REVERSE"
+                }else if(state == 16){
                     stateString = "STOP_QUICKSTOP"
                 }else{
                     stateString = "UNKNOWN"


### PR DESCRIPTION
I wanted to open up this pull request for discussion about the way forward. 

Unfortunately, changing the ordering of the BalanceState/FloatState enum breaks some compatibility with devices communicating with the VESC over UART or CAN (like Rescue, Balance Buddy, Metr, or my addon board). Those devices receive BalanceState/FloatState as a part of the `COMM_GET_DECODED_BALANCE` message and expect certain values to correspond to certain states. By changing the ordering or adding/removing states, you're changing what those values mean. The second issue is that by removing the individual tiltback states and combining them all into one, you're removing a device's ability to tell the cause of tiltback. Devices that give different alerts for different tiltback states are no longer able to do so.

By simply reverting the old BalanceState/FloatState ordering and adding any new states to the end of the enum, you maintain compatibility at the expense of a nicely organized enum. You also allow users to switch between the Float and Balance packages without having to update their attached devices to make sure they understand the different values sent. That's what my pull request does, and it seems like the easiest solution for everyone. It brings back compatibility without any effect on functionality.

There are other solutions to this, such as modifying the data that's sent in CAN/UART packets, to include more information like the cause of tiltback. But, that might again break compatibility with devices expecting certain data in specific byte positions of those packets. 

The Float package can be a clean cut to doing things a new way, but you might have to anticipate people complaining when connected things aren't working right. And it would be good to make sure that whatever the new way is, it stays standardized in a way that won't continue to break compatibility with each future version. I'm not sure what the best solution to this is going forward, but that's why I wanted to open the discussion.

(@surfdado)