### PR TITLE
ADC refactor and a generic konami implementation

### DIFF
--- a/float/float/Makefile
+++ b/float/float/Makefile
@@ -2,7 +2,7 @@ VESC_TOOL ?= vesc_tool
 
 TARGET = float
 
-SOURCES = float.c footpad_sensor.c conf/buffer.c conf/confparser.c conf/confxml.c
+SOURCES = float.c footpad_sensor.c konami.c conf/buffer.c conf/confparser.c conf/confxml.c
 
 ADD_TO_CLEAN = conf/confxml.h conf/confxml.c
 

--- a/float/float/Makefile
+++ b/float/float/Makefile
@@ -2,7 +2,7 @@ VESC_TOOL ?= vesc_tool
 
 TARGET = float
 
-SOURCES = float.c conf/buffer.c conf/confparser.c conf/confxml.c
+SOURCES = float.c footpad_sensor.c conf/buffer.c conf/confparser.c conf/confxml.c
 
 ADD_TO_CLEAN = conf/confxml.h conf/confxml.c
 

--- a/float/float/conf/conf_default.h
+++ b/float/float/conf/conf_default.h
@@ -175,7 +175,7 @@
 
 // Return To Level Speed
 #ifndef APPCONF_FLOAT_TILTBACK_RETURN_SPEED
-#define APPCONF_FLOAT_TILTBACK_RETURN_SPEED 5
+#define APPCONF_FLOAT_TILTBACK_RETURN_SPEED 1
 #endif
 
 // Constant Tiltback

--- a/float/float/conf/settings.xml
+++ b/float/float/conf/settings.xml
@@ -790,7 +790,7 @@ p, li { white-space: pre-wrap; }
             <minDouble>0</minDouble>
             <showDisplay>0</showDisplay>
             <stepDouble>0.5</stepDouble>
-            <valDouble>5</valDouble>
+            <valDouble>1</valDouble>
             <vTxDoubleScale>100</vTxDoubleScale>
             <suffix> °/s</suffix>
             <vTx>7</vTx>

--- a/float/float/float.c
+++ b/float/float/float.c
@@ -32,6 +32,9 @@
 // Acceleration average
 #define ACCEL_ARRAY_SIZE 40
 
+// ADC Hand-Press Scale Factor (Accomdate lighter presses than what's needed for engagement by foot)
+#define ADC_HAND_PRESS_SCALE 0.8
+
 HEADER
 
 // Return the sign of the argument. -1.0 if negative, 1.0 if zero or positive.
@@ -207,8 +210,10 @@ typedef struct {
 	bool enable_upside_down;		// dark ride mode is enabled (10 seconds after fault)
 	float delay_upside_down_fault;
 	float darkride_setpoint_correction;
+
+	// Feature: Flywheel
 	bool is_flywheel_mode, flywheel_abort, flywheel_allow_abort;
-	float flywheel_pitch_offset, flywheel_roll_offset, flywheel_konami_timer;
+	float flywheel_pitch_offset, flywheel_roll_offset, flywheel_konami_timer, flywheel_konami_pitch, flywheel_fault_adc1, flywheel_fault_adc2;
 	int flywheel_konami_state;
 
 	// Feature: Handtest
@@ -249,6 +254,7 @@ static void brake(data *d);
 static void set_current(data *d, float current);
 static void flywheel_stop(data *d);
 static void cmd_flywheel_toggle(data *d, unsigned char *cfg, int len);
+static bool flywheel_konami_check(data *d, int input);
 
 /**
  * BUZZER / BEEPER on Servo Pin
@@ -479,6 +485,8 @@ static void configure(data *d) {
 	d->enable_upside_down = false;
 	d->is_upside_down = false;
 	d->darkride_setpoint_correction = d->float_conf.dark_pitch_offset;
+
+	// Feature: Flywheel
 	d->is_flywheel_mode = false;
 	d->flywheel_abort = false;
 	d->flywheel_allow_abort = false;
@@ -840,10 +848,8 @@ static bool check_faults(data *d){
 			}
 		}
 
-		if(d->is_flywheel_mode && d->flywheel_allow_abort) {
-			//if(d->adc1 > (d->float_conf.fault_adc1 * 0.8) || d->adc2 > (d->float_conf.fault_adc2 * 0.8)) {
-			if(d->adc1 > 1 && d->adc2 > 1) {
-				// this is a hand-press, accept 80% of normal ADC threshold to turn it off board
+		if (d->is_flywheel_mode && d->flywheel_allow_abort) {
+			if (d->adc1 > (d->flywheel_fault_adc1 * ADC_HAND_PRESS_SCALE) && d->adc2 > (d->flywheel_fault_adc2 * ADC_HAND_PRESS_SCALE)) {
 				d->state = FAULT_SWITCH_HALF;
 				d->flywheel_abort = true;
 				return true;
@@ -2064,21 +2070,35 @@ static void float_thd(void *arg) {
 					break;
 				}
 			}
-			if(!d->is_flywheel_mode && d->flywheel_konami_state == 0 && d->true_pitch_angle > 75 && d->true_pitch_angle < 105 && d->adc1 > 1 && d->adc2 < 1){
+			
+			if ((d->flywheel_konami_state == 0) && flywheel_konami_check(d, 1)) { // LEFT
 				d->flywheel_konami_state = 1;
 				d->flywheel_konami_timer = d->current_time;
-			}else if(!d->is_flywheel_mode && d->flywheel_konami_state == 1 && d->true_pitch_angle > 75 && d->true_pitch_angle < 105 && d->adc1 < 1 && d->adc2 > 1){
+				d->flywheel_konami_pitch = d->true_pitch_angle;
+			} else if ((d->flywheel_konami_state == 1) && flywheel_konami_check(d, 0)) { // _
 				d->flywheel_konami_state = 2;
 				d->flywheel_konami_timer = d->current_time;
-			}else if(!d->is_flywheel_mode && d->flywheel_konami_state == 2 && d->true_pitch_angle > 75 && d->true_pitch_angle < 105 && d->adc1 > 1 && d->adc2 < 1){
+			} else if ((d->flywheel_konami_state == 2) && flywheel_konami_check(d, 2)) { // RIGHT
 				d->flywheel_konami_state = 3;
 				d->flywheel_konami_timer = d->current_time;
-			}else if(!d->is_flywheel_mode && d->flywheel_konami_state == 3 && d->true_pitch_angle > 75 && d->true_pitch_angle < 105 && d->adc1 < 1 && d->adc2 > 1){
+			} else if ((d->flywheel_konami_state == 3) && flywheel_konami_check(d, 0)) { // _
 				d->flywheel_konami_state = 4;
+				d->flywheel_konami_timer = d->current_time;
+			} else if ((d->flywheel_konami_state == 4) && flywheel_konami_check(d, 1)) { // LEFT
+				d->flywheel_konami_state = 5;
+				d->flywheel_konami_timer = d->current_time;
+			} else if ((d->flywheel_konami_state == 5) && flywheel_konami_check(d, 0)) { // _
+				d->flywheel_konami_state = 6;
+				d->flywheel_konami_timer = d->current_time;
+			} else if ((d->flywheel_konami_state == 6) && flywheel_konami_check(d, 2)) { // RIGHT (ENABLE FLYWHEEL)
+				d->flywheel_konami_state = 7;
 				d->flywheel_konami_timer = d->current_time;
 				unsigned char enabled[6] = {0x82, 0, 0, 0, 0, 1};
 				cmd_flywheel_toggle(d, enabled, 6);
-			}else if(d->current_time - d->flywheel_konami_timer > 1.0){
+			} else if ((d->current_time - d->flywheel_konami_timer > 0.5) ||																						// Timeout
+					  ((d->flywheel_konami_state == 4) && flywheel_konami_check(d, 2)) || 									   										// Right Press when expecting Left
+					  (((d->flywheel_konami_state == 2) || (d->flywheel_konami_state == 6)) && flywheel_konami_check(d, 1)) || 										// Left Press when expecting Right
+					  (((d->flywheel_konami_state == 1) || (d->flywheel_konami_state == 3) || (d->flywheel_konami_state == 5)) && flywheel_konami_check(d, 3))) {	// Double Press when expecting None
 				d->flywheel_konami_state = 0;
 			}
 
@@ -2873,6 +2893,10 @@ static void cmd_flywheel_toggle(data *d, unsigned char *cfg, int len)
 		}
 		d->flywheel_abort = false;
 
+		// Temp store ADC Fault Thresholds
+		d->flywheel_fault_adc1 = d->float_conf.fault_adc1;
+		d->flywheel_fault_adc2 = d->float_conf.fault_adc2;
+
 		// Tighter startup/fault tolerances
 		d->startup_pitch_tolerance = 0.2;
 		d->float_conf.startup_pitch_tolerance = 0.2;
@@ -2959,6 +2983,38 @@ void flywheel_stop(data *d)
 	VESC_IF->set_cfg_float(CFG_PARAM_l_max_erpm + 100, 30000);
 	read_cfg_from_eeprom(d);
 	configure(d);
+}
+
+bool flywheel_konami_check(data *d, int input) 
+{
+	if((!d->is_flywheel_mode) && (d->true_pitch_angle > 75) && (d->true_pitch_angle < 105) && // Check that Flywheel is inactive and board is within reasonable pitch range
+	   ((d->flywheel_konami_state == 0) || (fabsf(d->true_pitch_angle - d->flywheel_konami_pitch) < 2.5)))
+	{
+		switch(input) {
+		case 1: // ADC 1 Pressed
+			if ((d->adc1 > d->float_conf.fault_adc1 * ADC_HAND_PRESS_SCALE) && (d->adc2 < d->float_conf.fault_adc2 * ADC_HAND_PRESS_SCALE)) {
+				return true;
+			}
+			break;
+		case 2: // ADC 2 Pressed
+			if ((d->adc1 < d->float_conf.fault_adc1 * ADC_HAND_PRESS_SCALE) && (d->adc2 > d->float_conf.fault_adc2 * ADC_HAND_PRESS_SCALE)) {
+				return true;
+			}
+			break;
+		case 3: // ADC 1 + 2 Pressed
+			if ((d->adc1 > d->float_conf.fault_adc1 * ADC_HAND_PRESS_SCALE) && (d->adc2 > d->float_conf.fault_adc2 * ADC_HAND_PRESS_SCALE)) {
+				return true;
+			}
+			break;
+		default: // No ADC Pressed
+			if ((d->adc1 < d->float_conf.fault_adc1 * ADC_HAND_PRESS_SCALE) && (d->adc2 < d->float_conf.fault_adc2 * ADC_HAND_PRESS_SCALE)) {
+				return true;
+			}
+			break;
+		}
+	}
+	
+	return false; // Reached if any conditions along the way are failed
 }
 
 // Handler for incoming app commands

--- a/float/float/float.c
+++ b/float/float/float.c
@@ -20,6 +20,8 @@
 
 #include "vesc_c_if.h"
 
+#include "footpad_sensor.h"
+
 #include "conf/datatypes.h"
 #include "conf/confparser.h"
 #include "conf/confxml.h"
@@ -88,18 +90,6 @@ typedef enum {
 	TILTBACK_LV,
 	TILTBACK_TEMP
 } SetpointAdjustmentType;
-
-typedef enum {
-	FS_NONE = 0,
-	FS_LEFT = 1,
-	FS_RIGHT = 2,
-	FS_BOTH = 3
-} FootpadSensorState;
-
-typedef struct {
-	float adc1, adc2;
-	FootpadSensorState state;
-} FootpadSensor;
 
 typedef struct{
 	float a0, a1, a2, b1, b2;
@@ -669,59 +659,6 @@ static float get_setpoint_adjustment_step_size(data *d) {
 			;
 	}
 	return 0;
-}
-
-// Read ADCs and determine footpad sensor state
-static FootpadSensorState footpad_sensor_state_evaluate(const FootpadSensor *fs, const float_config *config) {
-	// Calculate sensor state from ADC values
-	if (config->fault_adc1 == 0 && config->fault_adc2 == 0) { // No sensors
-		return FS_BOTH;
-	} else if (config->fault_adc2 == 0) { // Single sensor on ADC1
-		if (fs->adc1 > config->fault_adc1) {
-			return FS_BOTH;
-		}
-	} else if (config->fault_adc1 == 0) { // Single sensor on ADC2
-		if (fs->adc2 > config->fault_adc2) {
-			return FS_BOTH;
-		}
-	} else { // Double sensor
-		if (fs->adc1 > config->fault_adc1) {
-			if (fs->adc2 > config->fault_adc2) {
-				return FS_BOTH;
-			} else {
-				return FS_LEFT;
-			}
-		} else {
-			if (fs->adc2 > config->fault_adc2) {
-				return FS_RIGHT;
-			}
-		}
-	}
-
-	return FS_NONE;
-}
-
-static void footpad_sensor_update(FootpadSensor *fs, const float_config *config) {
-	fs->adc1 = VESC_IF->io_read_analog(VESC_PIN_ADC1);
-	fs->adc2 = VESC_IF->io_read_analog(VESC_PIN_ADC2); // Returns -1.0 if the pin is missing on the hardware
-	if (fs->adc2 < 0.0) {
-		fs->adc2 = 0.0;
-	}
-
-	fs->state = footpad_sensor_state_evaluate(fs, config);
-}
-
-static int footpad_sensor_state_to_switch_compat(FootpadSensorState v) {
-	switch (v) {
-	case FS_BOTH:
-		return 2;
-	case FS_LEFT:
-	case FS_RIGHT:
-		return 1;
-	case FS_NONE:
-	default:
-		return 0;
-	}
 }
 
 // Fault checking order does not really matter. From a UX perspective, switch should be before angle.

--- a/float/float/float.c
+++ b/float/float/float.c
@@ -2023,14 +2023,11 @@ static void float_thd(void *arg) {
 		case (FAULT_SWITCH_HALF):
 		case (FAULT_SWITCH_FULL):
 		case (FAULT_STARTUP):
-			if (d->is_flywheel_mode) {
-				if ((d->flywheel_abort) ||	// single-pad pressed while balancing upright
-					(d->flywheel_allow_abort && d->footpad_sensor.adc1 > 1 && d->footpad_sensor.adc2 > 1)) {
-					flywheel_stop(d);
-					break;
-				}
+			if (d->is_flywheel_mode && d->flywheel_abort) {
+				flywheel_stop(d);
+				break;
 			}
-			
+
 			if ((d->flywheel_konami_state == 0) && flywheel_konami_check(d, 1)) { // LEFT
 				d->flywheel_konami_state = 1;
 				d->flywheel_konami_timer = d->current_time;

--- a/float/float/float.c
+++ b/float/float/float.c
@@ -689,14 +689,7 @@ static SwitchState check_adcs(data *d) {
 		if(d->adc1 > d->float_conf.fault_adc1 && d->adc2 > d->float_conf.fault_adc2){
 			sw_state = ON;
 		}else if(d->adc1 > d->float_conf.fault_adc1 || d->adc2 > d->float_conf.fault_adc2){
-			// 5 seconds after stopping we allow starting with a single sensor (e.g. for jump starts)
-			bool is_simple_start = d->float_conf.startup_simplestart_enabled &&
-				(d->current_time - d->disengage_timer > 5);
-
-			if (d->float_conf.fault_is_dual_switch || is_simple_start)
-				sw_state = ON;
-			else
-				sw_state = HALF;
+			sw_state = HALF;
 		}else{
 			sw_state = OFF;
 		}
@@ -1793,6 +1786,16 @@ static void float_thd(void *arg) {
 			d->yaw_aggregate += d->yaw_change;
 
 		d->switch_state = check_adcs(d);
+
+		if (d->switch_state == HALF) {
+			// 5 seconds after stopping we allow starting with a single sensor (e.g. for jump starts)
+			bool is_simple_start = d->float_conf.startup_simplestart_enabled &&
+				(d->current_time - d->disengage_timer > 5);
+
+			if (d->float_conf.fault_is_dual_switch || is_simple_start) {
+				d->switch_state = ON;
+			}
+		}
 
 		if (d->switch_state == OFF && d->state <= RUNNING_TILTBACK && d->abs_erpm > d->switch_warn_buzz_erpm) {
 			// If we're at riding speed and the switch is off => ALERT the user

--- a/float/float/float.c
+++ b/float/float/float.c
@@ -702,16 +702,6 @@ static SwitchState check_adcs(data *d) {
 		}
 	}
 
-	if (sw_state == OFF && d->state <= RUNNING_TILTBACK && d->abs_erpm > d->switch_warn_buzz_erpm) {
-		// If we're at riding speed and the switch is off => ALERT the user
-		// set force=true since this could indicate an imminent shutdown/nosedive
-		beep_on(d, true);
-		d->beep_reason = BEEP_SENSORS;
-	} else {
-		// if the switch comes back on we stop buzzing
-		beep_off(d, false);
-	}
-
 	return sw_state;
 }
 
@@ -1803,6 +1793,16 @@ static void float_thd(void *arg) {
 			d->yaw_aggregate += d->yaw_change;
 
 		d->switch_state = check_adcs(d);
+
+		if (d->switch_state == OFF && d->state <= RUNNING_TILTBACK && d->abs_erpm > d->switch_warn_buzz_erpm) {
+			// If we're at riding speed and the switch is off => ALERT the user
+			// set force=true since this could indicate an imminent shutdown/nosedive
+			beep_on(d, true);
+			d->beep_reason = BEEP_SENSORS;
+		} else {
+			// if the switch comes back on we stop buzzing
+			beep_off(d, false);
+		}
 
 		// Log Values
 		d->float_setpoint = d->setpoint;

--- a/float/float/float.c
+++ b/float/float/float.c
@@ -36,9 +36,6 @@
 // Acceleration average
 #define ACCEL_ARRAY_SIZE 40
 
-// ADC Hand-Press Scale Factor (Accomdate lighter presses than what's needed for engagement by foot)
-#define ADC_HAND_PRESS_SCALE 0.8
-
 HEADER
 
 // Return the sign of the argument. -1.0 if negative, 1.0 if zero or positive.
@@ -818,7 +815,8 @@ static bool check_faults(data *d){
 		}
 
 		if (d->is_flywheel_mode && d->flywheel_allow_abort) {
-			if (d->footpad_sensor.adc1 > (d->float_conf.fault_adc1 * ADC_HAND_PRESS_SCALE) && d->footpad_sensor.adc2 > (d->float_conf.fault_adc1 * ADC_HAND_PRESS_SCALE)) {
+			FootpadSensorState state = footpad_sensor_state_evaluate(&d->footpad_sensor, &d->float_conf, true);
+			if (state == FS_BOTH) {
 				d->state = FAULT_SWITCH_HALF;
 				d->flywheel_abort = true;
 				return true;
@@ -2049,7 +2047,7 @@ static void float_thd(void *arg) {
 
 			// Check that Flywheel is inactive and board is within reasonable pitch range
 			if((!d->is_flywheel_mode) && (d->true_pitch_angle > 75) && (d->true_pitch_angle < 105)) {
-				if (konami_check(&d->flywheel_konami, &d->footpad_sensor, d->current_time)) {
+				if (konami_check(&d->flywheel_konami, &d->footpad_sensor, &d->float_conf, d->current_time)) {
 					unsigned char enabled[6] = {0x82, 0, 0, 0, 0, 1};
 					cmd_flywheel_toggle(d, enabled, 6);
 				}

--- a/float/float/float.c
+++ b/float/float/float.c
@@ -661,6 +661,24 @@ static float get_setpoint_adjustment_step_size(data *d) {
 	return 0;
 }
 
+bool is_engaged(const data *d) {
+	if (d->footpad_sensor.state == FS_BOTH) {
+		return true;
+	}
+
+	if (d->footpad_sensor.state == FS_LEFT || d->footpad_sensor.state == FS_RIGHT) {
+		// 5 seconds after stopping we allow starting with a single sensor (e.g. for jump starts)
+		bool is_simple_start = d->float_conf.startup_simplestart_enabled &&
+			(d->current_time - d->disengage_timer > 5);
+
+		if (d->float_conf.fault_is_dual_switch || is_simple_start) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 // Fault checking order does not really matter. From a UX perspective, switch should be before angle.
 static bool check_faults(data *d){
 	// Aggressive reverse stop in case the board runs off when upside down
@@ -693,7 +711,7 @@ static bool check_faults(data *d){
 				d->fault_angle_roll_timer = d->current_time;
 			}
 		}
-		if (d->footpad_sensor.state == FS_BOTH) {
+		if (is_engaged(d)) {
 			// allow turning it off by engaging foot sensors
 			d->state = FAULT_SWITCH_HALF;
 			return true;
@@ -761,7 +779,7 @@ static bool check_faults(data *d){
 
 		// Switch partially open and stopped
 		if(!d->float_conf.fault_is_dual_switch) {
-			if(d->footpad_sensor.state != FS_BOTH && d->abs_erpm < d->float_conf.fault_adc_half_erpm){
+			if(!is_engaged(d) && d->abs_erpm < d->float_conf.fault_adc_half_erpm){
 				if ((1000.0 * (d->current_time - d->fault_switch_half_timer)) > d->float_conf.fault_delay_switch_half){
 					d->state = FAULT_SWITCH_HALF;
 					return true;
@@ -1745,16 +1763,6 @@ static void float_thd(void *arg) {
 
 		footpad_sensor_update(&d->footpad_sensor, &d->float_conf);
 
-		if (d->footpad_sensor.state == FS_LEFT || d->footpad_sensor.state == FS_RIGHT) {
-			// 5 seconds after stopping we allow starting with a single sensor (e.g. for jump starts)
-			bool is_simple_start = d->float_conf.startup_simplestart_enabled &&
-				(d->current_time - d->disengage_timer > 5);
-
-			if (d->float_conf.fault_is_dual_switch || is_simple_start) {
-				d->footpad_sensor.state = FS_BOTH;
-			}
-		}
-
 		if (d->footpad_sensor.state == FS_NONE && d->state <= RUNNING_TILTBACK && d->abs_erpm > d->switch_warn_buzz_erpm) {
 			// If we're at riding speed and the switch is off => ALERT the user
 			// set force=true since this could indicate an imminent shutdown/nosedive
@@ -2096,7 +2104,7 @@ static void float_thd(void *arg) {
 			// Check for valid startup position and switch state
 			if (fabsf(d->pitch_angle) < d->startup_pitch_tolerance &&
 				fabsf(d->roll_angle) < d->float_conf.startup_roll_tolerance && 
-				d->footpad_sensor.state == FS_BOTH) {
+				is_engaged(d)) {
 				reset_vars(d);
 				break;
 			}
@@ -2110,7 +2118,7 @@ static void float_thd(void *arg) {
 				}
 			}
 			// Push-start aka dirty landing Part II
-			if(d->float_conf.startup_pushstart_enabled && (d->abs_erpm > 1000) && d->footpad_sensor.state == FS_BOTH) {
+			if(d->float_conf.startup_pushstart_enabled && (d->abs_erpm > 1000) && is_engaged(d)) {
 				if ((fabsf(d->pitch_angle) < 45) && (fabsf(d->roll_angle) < 45)) {
 					// 45 to prevent board engaging when upright or laying sideways
 					// 45 degree tolerance is more than plenty for tricks / extreme mounts

--- a/float/float/float.c
+++ b/float/float/float.c
@@ -702,19 +702,12 @@ static SwitchState check_adcs(data *d) {
 		}
 	}
 
-	if ((sw_state == OFF) && (d->state <= RUNNING_TILTBACK)) {
-		if (d->abs_erpm > d->switch_warn_buzz_erpm) {
-			// If we're at riding speed and the switch is off => ALERT the user
-			// set force=true since this could indicate an imminent shutdown/nosedive
-			beep_on(d, true);
-			d->beep_reason = BEEP_SENSORS;
-		}
-		else {
-			// if we drop below riding speed stop buzzing
-			beep_off(d, false);
-		}
-	}
-	else {
+	if (sw_state == OFF && d->state <= RUNNING_TILTBACK && d->abs_erpm > d->switch_warn_buzz_erpm) {
+		// If we're at riding speed and the switch is off => ALERT the user
+		// set force=true since this could indicate an imminent shutdown/nosedive
+		beep_on(d, true);
+		d->beep_reason = BEEP_SENSORS;
+	} else {
 		// if the switch comes back on we stop buzzing
 		beep_off(d, false);
 	}

--- a/float/float/float.c
+++ b/float/float/float.c
@@ -28,6 +28,8 @@
 #include "conf/buffer.h"
 #include "conf/conf_default.h"
 
+#include "konami.h"
+
 #include <math.h>
 #include <string.h>
 
@@ -100,6 +102,8 @@ typedef enum {
 	BQ_LOWPASS,
 	BQ_HIGHPASS
 } BiquadType;
+
+static const FootpadSensorState flywheel_konami_sequence[] = { FS_LEFT, FS_NONE, FS_RIGHT, FS_NONE, FS_LEFT, FS_NONE, FS_RIGHT };
 
 // This is all persistent state of the application, which will be allocated in init. It
 // is put here because variables can only be read-only when this program is loaded
@@ -208,8 +212,7 @@ typedef struct {
 
 	// Feature: Flywheel
 	bool is_flywheel_mode, flywheel_abort, flywheel_allow_abort;
-	float flywheel_pitch_offset, flywheel_roll_offset, flywheel_konami_timer, flywheel_konami_pitch;
-	int flywheel_konami_state;
+	float flywheel_pitch_offset, flywheel_roll_offset;
 
 	// Feature: Handtest
 	bool do_handtest;
@@ -243,13 +246,14 @@ typedef struct {
 	int debug_render_1, debug_render_2;
 	int debug_sample_field, debug_sample_count, debug_sample_index;
 	int debug_experiment_1, debug_experiment_2, debug_experiment_3, debug_experiment_4, debug_experiment_5, debug_experiment_6;
+
+	Konami flywheel_konami;
 } data;
 
 static void brake(data *d);
 static void set_current(data *d, float current);
 static void flywheel_stop(data *d);
 static void cmd_flywheel_toggle(data *d, unsigned char *cfg, int len);
-static bool flywheel_konami_check(data *d, int input);
 
 /**
  * BUZZER / BEEPER on Servo Pin
@@ -518,6 +522,8 @@ static void configure(data *d) {
 	}
 
 	d->do_handtest = false;
+
+	konami_init(&d->flywheel_konami, flywheel_konami_sequence, sizeof(flywheel_konami_sequence));
 }
 
 static void reset_vars(data *d) {
@@ -2041,35 +2047,12 @@ static void float_thd(void *arg) {
 				break;
 			}
 
-			if ((d->flywheel_konami_state == 0) && flywheel_konami_check(d, 1)) { // LEFT
-				d->flywheel_konami_state = 1;
-				d->flywheel_konami_timer = d->current_time;
-				d->flywheel_konami_pitch = d->true_pitch_angle;
-			} else if ((d->flywheel_konami_state == 1) && flywheel_konami_check(d, 0)) { // _
-				d->flywheel_konami_state = 2;
-				d->flywheel_konami_timer = d->current_time;
-			} else if ((d->flywheel_konami_state == 2) && flywheel_konami_check(d, 2)) { // RIGHT
-				d->flywheel_konami_state = 3;
-				d->flywheel_konami_timer = d->current_time;
-			} else if ((d->flywheel_konami_state == 3) && flywheel_konami_check(d, 0)) { // _
-				d->flywheel_konami_state = 4;
-				d->flywheel_konami_timer = d->current_time;
-			} else if ((d->flywheel_konami_state == 4) && flywheel_konami_check(d, 1)) { // LEFT
-				d->flywheel_konami_state = 5;
-				d->flywheel_konami_timer = d->current_time;
-			} else if ((d->flywheel_konami_state == 5) && flywheel_konami_check(d, 0)) { // _
-				d->flywheel_konami_state = 6;
-				d->flywheel_konami_timer = d->current_time;
-			} else if ((d->flywheel_konami_state == 6) && flywheel_konami_check(d, 2)) { // RIGHT (ENABLE FLYWHEEL)
-				d->flywheel_konami_state = 7;
-				d->flywheel_konami_timer = d->current_time;
-				unsigned char enabled[6] = {0x82, 0, 0, 0, 0, 1};
-				cmd_flywheel_toggle(d, enabled, 6);
-			} else if ((d->current_time - d->flywheel_konami_timer > 0.5) ||																						// Timeout
-					  ((d->flywheel_konami_state == 4) && flywheel_konami_check(d, 2)) || 									   										// Right Press when expecting Left
-					  (((d->flywheel_konami_state == 2) || (d->flywheel_konami_state == 6)) && flywheel_konami_check(d, 1)) || 										// Left Press when expecting Right
-					  (((d->flywheel_konami_state == 1) || (d->flywheel_konami_state == 3) || (d->flywheel_konami_state == 5)) && flywheel_konami_check(d, 3))) {	// Double Press when expecting None
-				d->flywheel_konami_state = 0;
+			// Check that Flywheel is inactive and board is within reasonable pitch range
+			if((!d->is_flywheel_mode) && (d->true_pitch_angle > 75) && (d->true_pitch_angle < 105)) {
+				if (konami_check(&d->flywheel_konami, &d->footpad_sensor, d->current_time)) {
+					unsigned char enabled[6] = {0x82, 0, 0, 0, 0, 1};
+					cmd_flywheel_toggle(d, enabled, 6);
+				}
 			}
 
 			if (d->current_time - d->disengage_timer > 10) {
@@ -2948,38 +2931,6 @@ void flywheel_stop(data *d)
 	VESC_IF->set_cfg_float(CFG_PARAM_l_max_erpm + 100, 30000);
 	read_cfg_from_eeprom(d);
 	configure(d);
-}
-
-bool flywheel_konami_check(data *d, int input) 
-{
-	if((!d->is_flywheel_mode) && (d->true_pitch_angle > 75) && (d->true_pitch_angle < 105) && // Check that Flywheel is inactive and board is within reasonable pitch range
-	   ((d->flywheel_konami_state == 0) || (fabsf(d->true_pitch_angle - d->flywheel_konami_pitch) < 2.5)))
-	{
-		switch(input) {
-		case 1: // ADC 1 Pressed
-			if ((d->footpad_sensor.adc1 > d->float_conf.fault_adc1 * ADC_HAND_PRESS_SCALE) && (d->footpad_sensor.adc2 < d->float_conf.fault_adc2 * ADC_HAND_PRESS_SCALE)) {
-				return true;
-			}
-			break;
-		case 2: // ADC 2 Pressed
-			if ((d->footpad_sensor.adc1 < d->float_conf.fault_adc1 * ADC_HAND_PRESS_SCALE) && (d->footpad_sensor.adc2 > d->float_conf.fault_adc2 * ADC_HAND_PRESS_SCALE)) {
-				return true;
-			}
-			break;
-		case 3: // ADC 1 + 2 Pressed
-			if ((d->footpad_sensor.adc1 > d->float_conf.fault_adc1 * ADC_HAND_PRESS_SCALE) && (d->footpad_sensor.adc2 > d->float_conf.fault_adc2 * ADC_HAND_PRESS_SCALE)) {
-				return true;
-			}
-			break;
-		default: // No ADC Pressed
-			if ((d->footpad_sensor.adc1 < d->float_conf.fault_adc1 * ADC_HAND_PRESS_SCALE) && (d->footpad_sensor.adc2 < d->float_conf.fault_adc2 * ADC_HAND_PRESS_SCALE)) {
-				return true;
-			}
-			break;
-		}
-	}
-	
-	return false; // Reached if any conditions along the way are failed
 }
 
 // Handler for incoming app commands

--- a/float/float/float.c
+++ b/float/float/float.c
@@ -668,34 +668,26 @@ static float get_setpoint_adjustment_step_size(data *d) {
 
 // Read ADCs and determine switch state
 static SwitchState check_adcs(data *d) {
-	SwitchState sw_state;
-
 	// Calculate switch state from ADC values
-	if(d->float_conf.fault_adc1 == 0 && d->float_conf.fault_adc2 == 0){ // No Switch
-		sw_state = ON;
-	}else if(d->float_conf.fault_adc2 == 0){ // Single switch on ADC1
-		if(d->adc1 > d->float_conf.fault_adc1){
-			sw_state = ON;
-		} else {
-			sw_state = OFF;
+	if (d->float_conf.fault_adc1 == 0 && d->float_conf.fault_adc2 == 0) { // No Switch
+		return ON;
+	} else if (d->float_conf.fault_adc2 == 0) { // Single switch on ADC1
+		if (d->adc1 > d->float_conf.fault_adc1) {
+			return ON;
 		}
-	}else if(d->float_conf.fault_adc1 == 0){ // Single switch on ADC2
-		if(d->adc2 > d->float_conf.fault_adc2){
-			sw_state = ON;
-		} else {
-			sw_state = OFF;
+	} else if (d->float_conf.fault_adc1 == 0) { // Single switch on ADC2
+		if (d->adc2 > d->float_conf.fault_adc2) {
+			return ON;
 		}
-	}else{ // Double switch
-		if(d->adc1 > d->float_conf.fault_adc1 && d->adc2 > d->float_conf.fault_adc2){
-			sw_state = ON;
-		}else if(d->adc1 > d->float_conf.fault_adc1 || d->adc2 > d->float_conf.fault_adc2){
-			sw_state = HALF;
-		}else{
-			sw_state = OFF;
+	} else { // Double switch
+		if (d->adc1 > d->float_conf.fault_adc1 && d->adc2 > d->float_conf.fault_adc2) {
+			return ON;
+		} else if (d->adc1 > d->float_conf.fault_adc1 || d->adc2 > d->float_conf.fault_adc2) {
+			return HALF;
 		}
 	}
 
-	return sw_state;
+	return OFF;
 }
 
 // Fault checking order does not really matter. From a UX perspective, switch should be before angle.

--- a/float/float/float.c
+++ b/float/float/float.c
@@ -1339,7 +1339,12 @@ static void apply_torquetilt(data *d) {
 		d->accel_gap = 0;
 	}
 
-	float atr_strength = (d->accel_gap > 0) ? d->float_conf.atr_strength_up : d->float_conf.atr_strength_down;
+	// d->accel_gap | > 0  | <= 0
+	// -------------+------+-------
+	//      forward | up   | down
+	//     !forward | down | up
+	float atr_strength = forward == (d->accel_gap > 0) ? d->float_conf.atr_strength_up : d->float_conf.atr_strength_down;
+
 	// from 3000 to 6000 erpm gradually crank up the torque response
 	if ((d->abs_erpm > 3000) && (!d->braking)) {
 		float speedboost = (d->abs_erpm - 3000) / 3000;

--- a/float/float/float.c
+++ b/float/float/float.c
@@ -596,7 +596,8 @@ static void check_odometer(data *d)
 {
 	// Make odometer persistent if we've gone 200m or more
 	if (d->odometer_dirty > 0) {
-		if (VESC_IF->mc_get_odometer() > d->odometer + 200) {
+		float stored_odo = VESC_IF->mc_get_odometer();
+		if ((stored_odo > d->odometer + 200) || (stored_odo < d->odometer - 10000)) {
 			if (d->odometer_dirty == 1) {
 				// Wait 10 seconds before writing to avoid writing if immediately continuing to ride
 				d->odo_timer = d->current_time;

--- a/float/float/footpad_sensor.c
+++ b/float/float/footpad_sensor.c
@@ -1,0 +1,56 @@
+#include "footpad_sensor.h"
+
+#include "vesc_c_if.h"
+
+// Read ADCs and determine footpad sensor state
+FootpadSensorState footpad_sensor_state_evaluate(const FootpadSensor *fs, const float_config *config) {
+	// Calculate sensor state from ADC values
+	if (config->fault_adc1 == 0 && config->fault_adc2 == 0) { // No sensors
+		return FS_BOTH;
+	} else if (config->fault_adc2 == 0) { // Single sensor on ADC1
+		if (fs->adc1 > config->fault_adc1) {
+			return FS_BOTH;
+		}
+	} else if (config->fault_adc1 == 0) { // Single sensor on ADC2
+		if (fs->adc2 > config->fault_adc2) {
+			return FS_BOTH;
+		}
+	} else { // Double sensor
+		if (fs->adc1 > config->fault_adc1) {
+			if (fs->adc2 > config->fault_adc2) {
+				return FS_BOTH;
+			} else {
+				return FS_LEFT;
+			}
+		} else {
+			if (fs->adc2 > config->fault_adc2) {
+				return FS_RIGHT;
+			}
+		}
+	}
+
+	return FS_NONE;
+}
+
+void footpad_sensor_update(FootpadSensor *fs, const float_config *config) {
+	fs->adc1 = VESC_IF->io_read_analog(VESC_PIN_ADC1);
+	fs->adc2 = VESC_IF->io_read_analog(VESC_PIN_ADC2); // Returns -1.0 if the pin is missing on the hardware
+	if (fs->adc2 < 0.0) {
+		fs->adc2 = 0.0;
+	}
+
+	fs->state = footpad_sensor_state_evaluate(fs, config);
+}
+
+int footpad_sensor_state_to_switch_compat(FootpadSensorState v) {
+	switch (v) {
+	case FS_BOTH:
+		return 2;
+	case FS_LEFT:
+	case FS_RIGHT:
+		return 1;
+	case FS_NONE:
+	default:
+		return 0;
+	}
+}

--- a/float/float/footpad_sensor.h
+++ b/float/float/footpad_sensor.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "conf/datatypes.h"
+
+typedef enum {
+	FS_NONE = 0,
+	FS_LEFT = 1,
+	FS_RIGHT = 2,
+	FS_BOTH = 3
+} FootpadSensorState;
+
+typedef struct {
+	float adc1, adc2;
+	FootpadSensorState state;
+} FootpadSensor;
+
+FootpadSensorState footpad_sensor_state_evaluate(const FootpadSensor *fs, const float_config *config);
+
+void footpad_sensor_update(FootpadSensor *fs, const float_config *config);
+
+int footpad_sensor_state_to_switch_compat(FootpadSensorState v);

--- a/float/float/footpad_sensor.h
+++ b/float/float/footpad_sensor.h
@@ -14,7 +14,7 @@ typedef struct {
 	FootpadSensorState state;
 } FootpadSensor;
 
-FootpadSensorState footpad_sensor_state_evaluate(const FootpadSensor *fs, const float_config *config);
+FootpadSensorState footpad_sensor_state_evaluate(const FootpadSensor *fs, const float_config *config, bool handpress);
 
 void footpad_sensor_update(FootpadSensor *fs, const float_config *config);
 

--- a/float/float/konami.c
+++ b/float/float/konami.c
@@ -12,13 +12,14 @@ static void konami_reset(Konami *konami) {
 	konami->state = 0;
 }
 
-bool konami_check(Konami *konami, const FootpadSensor *fs, float current_time) {
+bool konami_check(Konami *konami, const FootpadSensor *fs, const float_config *config, float current_time) {
 	if (konami->time > 0 && current_time - konami->time > 0.5) {
 		konami_reset(konami);
 		return false;
 	}
 
-	if (fs->state == konami->sequence[konami->state]) {
+	FootpadSensorState fs_state = footpad_sensor_state_evaluate(fs, config, true);
+	if (fs_state == konami->sequence[konami->state]) {
 		++konami->state;
 		if (konami->state == konami->sequence_size) {
 			konami_reset(konami);
@@ -26,7 +27,7 @@ bool konami_check(Konami *konami, const FootpadSensor *fs, float current_time) {
 		}
 
 		konami->time = current_time;
-	} else if (konami->state > 0 && fs->state != konami->sequence[konami->state - 1]) {
+	} else if (konami->state > 0 && fs_state != konami->sequence[konami->state - 1]) {
 		konami_reset(konami);
 	}
 

--- a/float/float/konami.c
+++ b/float/float/konami.c
@@ -1,0 +1,34 @@
+#include "konami.h"
+
+void konami_init(Konami *konami, const FootpadSensorState *sequence, uint8_t sequence_size) {
+	konami->time = 0;
+	konami->state = 0;
+	konami->sequence = sequence;
+	konami->sequence_size = sequence_size;
+}
+
+static void konami_reset(Konami *konami) {
+	konami->time = 0;
+	konami->state = 0;
+}
+
+bool konami_check(Konami *konami, const FootpadSensor *fs, float current_time) {
+	if (konami->time > 0 && current_time - konami->time > 0.5) {
+		konami_reset(konami);
+		return false;
+	}
+
+	if (fs->state == konami->sequence[konami->state]) {
+		++konami->state;
+		if (konami->state == konami->sequence_size) {
+			konami_reset(konami);
+			return true;
+		}
+
+		konami->time = current_time;
+	} else if (konami->state > 0 && fs->state != konami->sequence[konami->state - 1]) {
+		konami_reset(konami);
+	}
+
+	return false;
+}

--- a/float/float/konami.h
+++ b/float/float/konami.h
@@ -11,4 +11,4 @@ typedef struct {
 
 void konami_init(Konami *konami, const FootpadSensorState *sequence, uint8_t sequence_size);
 
-bool konami_check(Konami *konami, const FootpadSensor *fs, float current_time);
+bool konami_check(Konami *konami, const FootpadSensor *fs, const float_config *config, float current_time);

--- a/float/float/konami.h
+++ b/float/float/konami.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "footpad_sensor.h"
+
+typedef struct {
+	float time;
+	uint8_t state;
+	const FootpadSensorState *sequence;
+	uint8_t sequence_size;
+} Konami;
+
+void konami_init(Konami *konami, const FootpadSensorState *sequence, uint8_t sequence_size);
+
+bool konami_check(Konami *konami, const FootpadSensor *fs, float current_time);

--- a/float/ui.qml.in
+++ b/float/ui.qml.in
@@ -676,7 +676,7 @@ Item {
 					}
 					Text {
 						id: versionText
-						text: "{{VERSION}}"
+						text: "{{VERSION}}b"
 						color: Utility.getAppHexColor("lightText")
 						font.pointSize: 10
 						font.weight: Font.Black


### PR DESCRIPTION
Cleans up the ADC handling, unifies the footpad sensor state with the Flywheel konami and adds a generic konami implementation, meaning one can easily define more konami sequences and hook them up with other features (controlling lights, switching tunes etc.).

The main goal of the refactor is to move functionality out of the monolithic ball of code into separate modules and to unify the ADC evaluation into a single place to avoid inconsistencies by design.