### PR TITLE
Fix flywheel roll offset

### DIFF
--- a/float/float/float.c
+++ b/float/float/float.c
@@ -1803,10 +1803,10 @@ static void float_thd(void *arg) {
 			d->true_pitch_angle = d->flywheel_pitch_offset - d->true_pitch_angle;
 			d->pitch_angle = d->true_pitch_angle;
 			d->roll_angle -= d->flywheel_roll_offset;
-			if (d->roll_angle < -200) {
+			if (d->roll_angle < -180) {
 				d->roll_angle += 360;
 			}
-			else if (d->roll_angle > 200) {
+			else if (d->roll_angle > 180) {
 				d->roll_angle -= 360;
 			}
 		}


### PR DESCRIPTION
Flywheel on my PintXV was failing into the `STOP_ANGLE_ROLL` state. While observing the `Roll` value in the `Float App RT Data`, I noticed it was transitioning from -200 to +160, the the usual transition point is -180 to +180. Given that roll is inherently unstable when pitch is +90, this extra 20 degrees of offset was contributing to flywheel stopping prematurely.